### PR TITLE
Fixes a calculation bug for Flexible Height

### DIFF
--- a/GreedoLayout/GreedoSizeCalculator.m
+++ b/GreedoLayout/GreedoSizeCalculator.m
@@ -94,13 +94,14 @@
         
     } else {
         CGFloat totalAspectRatio = 0.0;
+        CGFloat availableWidth = self.contentWidth - (self.leftOvers.count - 1) * self.interItemSpacing;
         
         for (NSValue *leftOver in self.leftOvers) {
             CGSize leftOverSize = [leftOver CGSizeValue];
             totalAspectRatio += (leftOverSize.width / leftOverSize.height);
         }
         
-        rowHeight = self.contentWidth / totalAspectRatio;
+        rowHeight = availableWidth / totalAspectRatio;
         enoughContentForTheRow = rowHeight < self.rowMaximumHeight;
     }
     


### PR DESCRIPTION
GreedoSizeCalculator didn't consider interItemSpacing when calculates rowHeight under !fixedHeight
this commit solves it.

I looked through your code, turned out the logic was there, but somehow it got removed during rewrite. not sure if it's intended but this commit solved my problem (calculated cell sizes don't not share the same ratio with original sizes).